### PR TITLE
Update default-property-interceptor.ts

### DIFF
--- a/src/default-property-interceptor.ts
+++ b/src/default-property-interceptor.ts
@@ -12,6 +12,7 @@ export function defaultPropertyInterceptor(this: StructuralObject, property: Ent
 
   if (newValue === undefined) newValue = null; // remove? to allow assignment to undefined in Babel constructors?
   let oldValue = rawAccessorFn();
+  if (oldValue === undefined) oldValue = null; // remove? to allow assignment to undefined in Babel constructors?
 
   let dataType = (property as any).dataType;
   if (dataType && dataType.parse) {


### PR DESCRIPTION
Having an issue with evaluating **undefined === null** which return **false** and the function continues when it should have stop. This is happening when intercepting navigation property defined in the entity parent class with  rawAccessorFn() returning undefined.